### PR TITLE
[Fix] : isLoggedIn 상태 쿠키의 토큰 상태값으로 변경

### DIFF
--- a/src/redux/slices/authSlice.ts
+++ b/src/redux/slices/authSlice.ts
@@ -1,3 +1,4 @@
+import { getCookie } from "@/utils/cookie";
 import { createSlice } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 
@@ -11,12 +12,12 @@ export type AuthState = {
 };
 
 //초기값 설정
-//쿠키로 해도되고 로컬스토리지에 저장된 USER_ID로 해도 되고
-//토큰의 만료 시간이 끝나지 않은 경우 + 로컬 스토리지에 해당 아이디 저장되어 있다면 앱 새고해도 로그인 상태를 유지
+//토큰의 만료 시간이 끝나지 않은 경우 앱 새고해도 로그인 상태를 유지
+const token = getCookie("accessToken"); //쿠키에 있는 accessToken으로 체크(1시간 유효)
 const userId = localStorage.getItem("USER_ID");
 
 const initialState: AuthState = {
-  isLoggedIn: !!userId, //로컬스토리지에 있는 유저 아이디 불리언 값으로 체크
+  isLoggedIn: !!token, //boolean 값으로 가져오기
   user: {
     id: userId!,
     nickname: "익명",


### PR DESCRIPTION
1시간 지나면 쿠키와 토큰은 만료되어 없어지는데 로컬스토리지에 넣어둔 USER_ID는 그대로이기 때문에
isLoggedIn이 쿠키의 토큰이 있는지 체크하는 것으로 변경